### PR TITLE
Fix typo in about page header

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import ankur from '../assets/img/Logos-Alianzas/ankurLogo.webp'
 	<main>
 		<h1 class="is-size-3 has-text-centered mt-6">Más de 25 Años de Experiencia en Energías Renovables y Oil & Gas</h1>
 		<div class="my-2">
-			<h2 class="is-size-4 py-6"> - Nuestra Experiecia</h2>
+                        <h2 class="is-size-4 py-6"> - Nuestra Experiencia</h2>
 			<p class="is-size-5-5">Contamos con un equipo de profesionales con una trayectoria de más de 25 años en el campo de las Energías Renovables (EERR), bajo la dirección técnica e integración de proyectos de Darío Gentile (Ing. Mecánico, Especialidad en EERR) Brindando servicios de análisis de factibilidad ejecución de proyectos energéticos integrales, ingeniería conceptual, básica y de ejecución de proyectos con modalidad EPC. Servicios de OyM, puesta en marcha y seguimiento, capacitación del personal.
 			</p>
 		</div>


### PR DESCRIPTION
## Summary
- correct a typo in `about.astro`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685ee3afce5883339c8ec2dea0fa4815