### PR TITLE
Add Jest setup with DOM tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "jest"
   },
   "dependencies": {
     "@astrojs/react": "^3.3.1",
@@ -20,5 +21,9 @@
     "framer-motion": "^11.1.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/scripts/changeType.js
+++ b/src/scripts/changeType.js
@@ -22,6 +22,8 @@ document.addEventListener("DOMContentLoaded", function () {
             renovablesContainer.classList.remove("hidden");
         }
     };
+    // Expose for testing
+    window.toggleVisibility = toggleVisibility;
 
     // Selección de todos los encabezados de las tarjetas
     const headers = document.querySelectorAll(".card-header.toggle-button");

--- a/tests/changeType.test.js
+++ b/tests/changeType.test.js
@@ -1,0 +1,43 @@
+import path from 'path';
+import { JSDOM } from 'jsdom';
+
+describe('toggleVisibility', () => {
+  let dom;
+
+  beforeEach(async () => {
+    dom = new JSDOM(`<!doctype html><html><body>
+      <div id="title-secction-ing"></div>
+      <div id="title-secction-ing-proyect"></div>
+      <div id="service-ing-container" class="hidden"></div>
+      <div id="service-ren-container" class="visible"></div>
+    </body></html>`, { url: 'http://localhost' });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.localStorage = dom.window.localStorage;
+
+    const modulePath = path.resolve('src/scripts/changeType.js');
+    await import(modulePath);
+
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+    delete global.localStorage;
+  });
+
+  test('shows ing container and hides ren container', () => {
+    window.toggleVisibility('ing');
+
+    const ing = document.getElementById('service-ing-container');
+    const ren = document.getElementById('service-ren-container');
+
+    expect(ing.classList.contains('visible')).toBe(true);
+    expect(ing.classList.contains('hidden')).toBe(false);
+    expect(ren.classList.contains('hidden')).toBe(true);
+    expect(ren.classList.contains('visible')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and jsdom to devDependencies
- expose `toggleVisibility` globally for testing
- set up Jest configuration
- create test covering `toggleVisibility`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ee3cca73c833387dfc53d73ce5c5c