### PR TITLE
Update README in Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,53 @@
-# Astro Starter Kit: Basics
+# Four Natural Energy (4NE)
 
-```sh
-npm create astro@latest -- --template basics
+Este repositorio contiene el código del sitio web corporativo de **Four Natural Energy**. El proyecto está construido con [Astro](https://astro.build/) y presenta los servicios y proyectos de la empresa en el sector de **Oil & Gas** y **Energías Renovables**.
+
+## Estructura del proyecto
+
 ```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
 /
-├── public/
-│   └── favicon.svg
+├── public/                # Archivos estáticos
 ├── src/
-│   ├── components/
-│   │   └── Card.astro
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
+│   ├── assets/            # Imágenes y archivos JSON con contenidos
+│   ├── components/        # Componentes Astro reutilizables
+│   ├── layouts/           # Plantillas base
+│   ├── pages/             # Páginas del sitio
+│   ├── scripts/           # Funciones en JavaScript para animaciones y navegación
+│   └── styles/            # Hojas de estilo
+├── astro.config.mjs       # Configuración de Astro
+├── package.json           # Dependencias y scripts de npm
+└── tsconfig.json          # Configuración de TypeScript
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Requisitos
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+- Node.js y npm instalados en el sistema.
 
-Any static assets, like images, can be placed in the `public/` directory.
+## Instalación
 
-## 🧞 Commands
+1. Clona este repositorio.
+2. Instala las dependencias:
+   ```bash
+   npm install
+   ```
+3. Inicia el servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+   Esto abrirá el sitio en `http://localhost:4321`.
 
-All commands are run from the root of the project, from a terminal:
+## Scripts disponibles
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+| Comando           | Descripción                                     |
+| ----------------- | ----------------------------------------------- |
+| `npm run dev`     | Inicia el servidor de desarrollo                |
+| `npm run build`   | Genera la versión estática en la carpeta `dist` |
+| `npm run preview` | Sirve localmente la versión construida          |
 
-## 👀 Want to learn more?
+## Despliegue
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+El sitio se genera de forma estática por lo que puede desplegarse en cualquier hosting que sirva archivos estáticos (por ejemplo GitHub Pages). Al ejecutar `npm run build` se crea la carpeta `dist/` con todos los archivos listos para producción.
+
+## Licencia
+
+Todos los contenidos son propiedad de Four Natural Energy.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Four Natural Energy (4NE)
 
+Este README está disponible en **español** e **inglés**. La versión en inglés se encuentra al final del documento.
+
 Este repositorio contiene el código del sitio web corporativo de **Four Natural Energy**. El proyecto está construido con [Astro](https://astro.build/) y presenta los servicios y proyectos de la empresa en el sector de **Oil & Gas** y **Energías Renovables**.
 
 ## Estructura del proyecto
@@ -51,3 +53,59 @@ El sitio se genera de forma estática por lo que puede desplegarse en cualquier 
 ## Licencia
 
 Todos los contenidos son propiedad de Four Natural Energy.
+
+---
+
+## English version
+
+This repository contains the source code for **Four Natural Energy**'s corporate website. The project is built with [Astro](https://astro.build/) and showcases the company's services and projects in the **Oil & Gas** and **Renewable Energy** sectors.
+
+### Project structure
+
+```
+/
+├── public/                # Static files
+├── src/
+│   ├── assets/            # Images and JSON content
+│   ├── components/        # Reusable Astro components
+│   ├── layouts/           # Base templates
+│   ├── pages/             # Site pages
+│   ├── scripts/           # JavaScript functions for animations and navigation
+│   └── styles/            # Stylesheets
+├── astro.config.mjs       # Astro configuration
+├── package.json           # npm dependencies and scripts
+└── tsconfig.json          # TypeScript configuration
+```
+
+### Requirements
+
+- Node.js and npm installed on your machine.
+
+### Installation
+
+1. Clone this repository.
+2. Install the dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   This will open the site at `http://localhost:4321`.
+
+### Available scripts
+
+| Command           | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `npm run dev`     | Starts the development server                  |
+| `npm run build`   | Generates the static version in the `dist` folder |
+| `npm run preview` | Serves the built version locally               |
+
+### Deployment
+
+The site is generated statically so it can be hosted on any static file server (for example GitHub Pages). Running `npm run build` creates the `dist/` folder with all files ready for production.
+
+### License
+
+All contents are property of Four Natural Energy.


### PR DESCRIPTION
## Summary
- replace the boilerplate starter README with a project specific introduction in Spanish

## Testing
- `npm run build` *(fails: astro not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685ee4e9db088333ad7d679184d923d4